### PR TITLE
Keep sync when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,51 @@
 [![Build Status](https://travis-ci.org/jeskew/async-seq.svg?branch=master)](https://travis-ci.org/jeskew/async-seq)
 
 This package provides a number of functions for filtering, reducing, combining,
-and otherwise transforming asynchronous iterators. Where possible, the functions
-in this library mirror those found on `Array.prototype`. Unlike the methods on
-`Array.prototype`, all functions are evaluated lazily and will only be applied
-to values as they are produced.
+and otherwise transforming synchronous or asynchronous iterables. Where
+possible, the functions in this library mirror those found on `Array.prototype`.
+Unlike the methods on `Array.prototype`, all functions are evaluated lazily and
+will only be applied to values as they are produced.
+
+## Synchronous and asynchronous iteration
+
+Functions that decorate a single iterator will return a synchronous iterable if
+called with a synchronous iterable and an asynchronous iterable if called with
+an asynchronous iterable. These functions may also be suffixed with `Sync` for
+strictly synchronous usage:
+
+```typescript
+import { map, mapSync } from '@jsq/async-seq';
+
+// Synchronous iterables can be decorated and still consumed synchronously
+declare function syncSequence(): Iterable<number>;
+const [first, second, third] = mapSync(x => x * x, syncSequence());
+
+// Asynchronous iterables must be consumed asynchronously
+declare function asyncSequence(): AsyncIterable<number>;
+const squares = map(x => x * x, asyncSequence())[Symbol.asyncIterator]();
+const { done, value } = await squares.next();
+
+// When unsure, use a consumer that can handle both types of iterator
+declare function anySequence(): Iterable<number>|AsyncIterable<number>;
+for await (const squared of map(x => x * x, asyncSequence())) {
+    // ...
+}
+```
+
+Functions that operate on multiple iterables, such as `zip`, `merge`,
+`interleave`, or `flatMap`, will always return asynchronous iterables.
+
+Functions that reduce iterables to a single value, such as `sum`, `collect`, or
+`reduce`, will always return a promise, though the provided iterator may be
+consumed synchronously.
+
+## Currying
 
 All functions take an iterable as their last argument, which allows you to curry
 and compose operators with `bind`:
 
 ```typescript
-import {filter} from '@jsq/async-seq';
+import { filter } from '@jsq/async-seq';
 
 const evens = filter.bind(null, x => x % 2 === 0);
 ```
@@ -24,7 +59,7 @@ proposal](https://github.com/tc39/proposal-pipeline-operator) (currently at
 stage 1) in mind:
 
 ```typescript
-import {filter, map, sum, takeWhile} from '@jsq/async-seq';
+import { filter, map, sum, takeWhile } from '@jsq/async-seq';
 
 function *fibonacci() {
     let i = 1, j = 1;
@@ -38,8 +73,7 @@ const sumOfAllEvenFibonacciNumbersUnderTenMillion = fibonacci()
     |> map.bind(null, x => x * x)
     |> filter.bind(null, x => x % 2 === 0)
     |> takeWhile.bind(null, x => x < 10000000)
-    |> sum
-    |> await;
+    |> sum;
 ```
 
 For documentation of the functions provided by this library, please see [the API

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Async sequence operators
 
-[![npm version](https://badge.fury.io/js/%40jsq%2Fasync-seq.svg)](https://badge.fury.io/js/%40jsq%2Fasync-seq)
-[![Apache 2 License](https://img.shields.io/github/license/jeskew/async-seq.svg?style=flat)](https://opensource.org/licenses/Apache-2.0)
-[![Build Status](https://travis-ci.org/jeskew/async-seq.svg?branch=master)](https://travis-ci.org/jeskew/async-seq)
+[![npm version](https://badge.fury.io/js/%40jsq%2Fseq.svg)](https://badge.fury.io/js/%40jsq%2Fseq)
+[![Apache 2 License](https://img.shields.io/github/license/jeskew/seq.svg?style=flat)](https://opensource.org/licenses/Apache-2.0)
+[![Build Status](https://travis-ci.org/jeskew/seq.svg?branch=master)](https://travis-ci.org/jeskew/seq)
 
 This package provides a number of functions for filtering, reducing, combining,
 and otherwise transforming synchronous or asynchronous iterables. Where
@@ -18,7 +18,7 @@ an asynchronous iterable. These functions may also be suffixed with `Sync` for
 strictly synchronous usage:
 
 ```typescript
-import { map, mapSync } from '@jsq/async-seq';
+import { map, mapSync } from '@jsq/seq';
 
 // Synchronous iterables can be decorated and still consumed synchronously
 declare function syncSequence(): Iterable<number>;
@@ -49,7 +49,7 @@ All functions take an iterable as their last argument, which allows you to curry
 and compose operators with `bind`:
 
 ```typescript
-import { filter } from '@jsq/async-seq';
+import { filter } from '@jsq/seq';
 
 const evens = filter.bind(null, x => x % 2 === 0);
 ```
@@ -59,7 +59,7 @@ proposal](https://github.com/tc39/proposal-pipeline-operator) (currently at
 stage 1) in mind:
 
 ```typescript
-import { filter, map, sum, takeWhile } from '@jsq/async-seq';
+import { filter, map, sum, takeWhile } from '@jsq/seq';
 
 function *fibonacci() {
     let i = 1, j = 1;
@@ -77,4 +77,4 @@ const sumOfAllEvenFibonacciNumbersUnderTenMillion = fibonacci()
 ```
 
 For documentation of the functions provided by this library, please see [the API
-documentation](https://jeskew.github.io/async-seq/).
+documentation](https://jeskew.github.io/seq/).

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup-plugin-typescript": "^0.8.1",
     "standard-version": "^4.2.0",
     "tape": "^4.9.0",
-    "typedoc": "^0.10.0",
+    "typedoc": "^0.11.0",
     "typescript": "^2.7"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@jsq/async-seq",
+  "name": "@jsq/seq",
   "version": "0.3.0",
-  "description": "Lazy sequence operators for JavaScript backed by async iterators.",
+  "description": "Lazy sequence operators for JavaScript.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jeskew/async-seq.git"
+    "url": "git+https://github.com/jeskew/seq.git"
   },
   "keywords": [
     "asynciterator",
@@ -28,9 +28,9 @@
   "author": "Jonathan Eskew <jonathan@jeskew.net>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/jeskew/async-seq/issues"
+    "url": "https://github.com/jeskew/seq/issues"
   },
-  "homepage": "https://github.com/jeskew/async-seq#readme",
+  "homepage": "https://github.com/jeskew/seq#readme",
   "devDependencies": {
     "@types/tape": "^4.2.31",
     "nyc": "^11.3.0",

--- a/src/AsyncIterableDecorator.ts
+++ b/src/AsyncIterableDecorator.ts
@@ -1,10 +1,12 @@
+import { iteratorFromIterable } from './iteratorFromIterable';
+
 export abstract class AsyncIterableDecorator<T> implements
     AsyncIterableIterator<T>
 {
-    protected readonly iterator: AsyncIterator<T>;
+    protected readonly iterator: Iterator<T>|AsyncIterator<T>;
 
-    constructor(iterable: AsyncIterable<T>) {
-        this.iterator = iterable[Symbol.asyncIterator]();
+    constructor(iterable: Iterable<T>|AsyncIterable<T>) {
+        this.iterator = iteratorFromIterable(iterable);
     }
 
     [Symbol.asyncIterator]() {
@@ -13,11 +15,11 @@ export abstract class AsyncIterableDecorator<T> implements
 
     abstract next(): Promise<IteratorResult<T>>;
 
-    return(): Promise<IteratorResult<T>> {
+    async return(): Promise<IteratorResult<T>> {
         if (typeof this.iterator.return === 'function') {
             return this.iterator.return();
         }
 
-        return Promise.resolve({done: true} as IteratorResult<T>);
+        return {done: true} as IteratorResult<T>;
     }
 }

--- a/src/AsyncIterableDecorator.ts
+++ b/src/AsyncIterableDecorator.ts
@@ -1,0 +1,23 @@
+export abstract class AsyncIterableDecorator<T> implements
+    AsyncIterableIterator<T>
+{
+    protected readonly iterator: AsyncIterator<T>;
+
+    constructor(iterable: AsyncIterable<T>) {
+        this.iterator = iterable[Symbol.asyncIterator]();
+    }
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    abstract next(): Promise<IteratorResult<T>>;
+
+    return(): Promise<IteratorResult<T>> {
+        if (typeof this.iterator.return === 'function') {
+            return this.iterator.return();
+        }
+
+        return Promise.resolve({done: true} as IteratorResult<T>);
+    }
+}

--- a/src/collect.spec.ts
+++ b/src/collect.spec.ts
@@ -1,11 +1,6 @@
 import { take, range } from '.';
 import { collect } from './collect';
-import {
-    asyncFibonacci,
-    CloseHandlingIterator,
-    ExplosiveIterator,
-    fibonacci,
-} from './testIterators.fixture';
+import { asyncFibonacci, fibonacci } from './testIterators.fixture';
 import * as test from 'tape';
 
 test('collect', async t => {
@@ -25,21 +20,4 @@ test('collect', async t => {
         [0, 1, 2, 3, 4, 5],
         await collect(range(6))
     )
-});
-
-test('collect error handling', async t => {
-    t.plan(2);
-
-    try {
-        await collect(new ExplosiveIterator);
-    } catch (err) {
-        t.equal(err.name, 'IterationDisallowedError');
-    }
-
-    const iter = new CloseHandlingIterator;
-    try {
-        await collect(iter);
-    } catch {
-        t.ok(iter.returnCalled, '.return should have been called');
-    }
 });

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -11,24 +11,16 @@ export async function collect<T>(iterable: Iterable<T>|AsyncIterable<T>) {
 
     const iterator = iterable[Symbol.asyncIterator]();
     const collected: Array<T> = [];
-    try {
-        for (
-            let next = await iterator.next(),
-                value = next.value,
-                done = next.done;
-            !done;
-            next = await iterator.next(),
+    for (
+        let next = await iterator.next(),
             value = next.value,
-            done = next.done
-        ) {
-            collected.push(value);
-        }
-    } catch (err) {
-        if (typeof iterator.return === 'function') {
-            await iterator.return();
-        }
-
-        throw err;
+            done = next.done;
+        !done;
+        next = await iterator.next(),
+        value = next.value,
+        done = next.done
+    ) {
+        collected.push(value);
     }
 
     return collected;

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -11,16 +11,24 @@ export async function collect<T>(iterable: Iterable<T>|AsyncIterable<T>) {
 
     const iterator = iterable[Symbol.asyncIterator]();
     const collected: Array<T> = [];
-    for (
-        let next = await iterator.next(),
+    try {
+        for (
+            let next = await iterator.next(),
+                value = next.value,
+                done = next.done;
+            !done;
+            next = await iterator.next(),
             value = next.value,
-            done = next.done;
-        !done;
-        next = await iterator.next(),
-        value = next.value,
-        done = next.done
-    ) {
-        collected.push(value);
+            done = next.done
+        ) {
+            collected.push(value);
+        }
+    } catch (err) {
+        if (typeof iterator.return === 'function') {
+            await iterator.return();
+        }
+
+        throw err;
     }
 
     return collected;

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -4,7 +4,9 @@ import { isSyncIterable } from './isIterable';
  * Collects the values yielded by a synchronous or asynchronous iterable into an
  * array.
  */
-export async function collect<T>(iterable: Iterable<T>|AsyncIterable<T>) {
+export async function collect<T>(
+    iterable: Iterable<T>|AsyncIterable<T>
+): Promise<Array<T>> {
     if (isSyncIterable(iterable)) {
         return [...iterable]
     }

--- a/src/distinct.spec.ts
+++ b/src/distinct.spec.ts
@@ -1,17 +1,34 @@
 import { collect, distinct, take } from '.';
-import { asyncFibonacci, fibonacci } from './testIterators.fixture';
+import {
+    asyncFibonacci,
+    CloseHandlingIterator,
+    ExplosiveIterator,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('distinct', async t => {
-    t.plan(2)
+    t.plan(4)
 
     t.deepEqual(
         [1, 2, 3, 5],
-        await collect(distinct(take(5, fibonacci())))
+        await collect(distinct([1, 1, 2, 3, 5]))
     )
 
     t.deepEqual(
         [1, 2, 3, 5],
         await collect(distinct(take(5, asyncFibonacci())))
     )
+
+    try {
+        await collect(distinct(new ExplosiveIterator))
+    } catch (err) {
+        t.equal(err.name, 'IterationDisallowedError');
+    }
+
+    const iter = new CloseHandlingIterator;
+    try {
+        await collect(distinct(iter))
+    } catch {
+        t.ok(iter.returnCalled)
+    }
 })

--- a/src/distinct.spec.ts
+++ b/src/distinct.spec.ts
@@ -1,13 +1,13 @@
 import { collect, distinct, take } from '.';
 import {
     asyncFibonacci,
-    CloseHandlingIterator,
-    ExplosiveIterator,
+    DECORATOR_ERROR_TEST_COUNT,
+    testDecoratorErrorHandling,
 } from './testIterators.fixture';
 import * as test from 'tape';
 
 test('distinct', async t => {
-    t.plan(4)
+    t.plan(2 + DECORATOR_ERROR_TEST_COUNT)
 
     t.deepEqual(
         [1, 2, 3, 5],
@@ -19,16 +19,5 @@ test('distinct', async t => {
         await collect(distinct(take(5, asyncFibonacci())))
     )
 
-    try {
-        await collect(distinct(new ExplosiveIterator))
-    } catch (err) {
-        t.equal(err.name, 'IterationDisallowedError');
-    }
-
-    const iter = new CloseHandlingIterator;
-    try {
-        await collect(distinct(iter))
-    } catch {
-        t.ok(iter.returnCalled)
-    }
+    await testDecoratorErrorHandling(distinct, t, 'distinct');
 })

--- a/src/distinct.ts
+++ b/src/distinct.ts
@@ -39,18 +39,17 @@ export function *distinctSync<T>(iterable: Iterable<T>): IterableIterator<T> {
 class Deduplicator<T> extends AsyncIterableDecorator<T> {
     private readonly seen = new Set<T>();
 
-    next(): Promise<IteratorResult<T>> {
-        return this.iterator.next().then(({done, value}) => {
-            if (done) {
-                return {done, value};
-            }
+    async next(): Promise<IteratorResult<T>> {
+        const { done, value } = await this.iterator.next();
+        if (done) {
+            return {done, value};
+        }
 
-            if (this.seen.has(value)) {
-                return this.next();
-            } else {
-                this.seen.add(value);
-                return {done, value};
-            }
-        })
+        if (this.seen.has(value)) {
+            return this.next();
+        } else {
+            this.seen.add(value);
+            return {done, value};
+        }
     }
 }

--- a/src/distinct.ts
+++ b/src/distinct.ts
@@ -1,3 +1,4 @@
+import { AsyncIterableDecorator } from './AsyncIterableDecorator';
 import { isSyncIterable } from './isIterable';
 
 /**
@@ -27,17 +28,8 @@ export function *distinctSync<T>(iterable: Iterable<T>): IterableIterator<T> {
     }
 }
 
-class Deduplicator<T> implements AsyncIterableIterator<T> {
-    private readonly iterator: AsyncIterator<T>;
+class Deduplicator<T> extends AsyncIterableDecorator<T> {
     private readonly seen = new Set<T>();
-
-    constructor(iterable: AsyncIterable<T>) {
-        this.iterator = iterable[Symbol.asyncIterator]();
-    }
-
-    [Symbol.asyncIterator]() {
-        return this;
-    }
 
     next(): Promise<IteratorResult<T>> {
         return this.iterator.next().then(({done, value}) => {
@@ -52,13 +44,5 @@ class Deduplicator<T> implements AsyncIterableIterator<T> {
                 return {done, value};
             }
         })
-    }
-
-    return(): Promise<IteratorResult<T>> {
-        if (typeof this.iterator.return === 'function') {
-            return this.iterator.return();
-        }
-
-        return Promise.resolve({done: true} as IteratorResult<T>);
     }
 }

--- a/src/distinct.ts
+++ b/src/distinct.ts
@@ -1,3 +1,5 @@
+import { isSyncIterable } from './isIterable';
+
 /**
  * Removes duplicates from a synchronous or asynchronous iterable.
  *
@@ -5,12 +7,58 @@
  * i.e., it is evaluated via the [`SameValueZero` algorithm](http://www.ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
  * described in the ECMAScript 2015 specification.
  */
-export async function *distinct<T>(iterable: Iterable<T>|AsyncIterable<T>) {
+export function distinct<T>(
+    iterable: Iterable<T>|AsyncIterable<T>
+): Iterable<T>|AsyncIterable<T> {
+    if (isSyncIterable(iterable)) {
+        return distinctSync(iterable);
+    }
+
+    return new Deduplicator(iterable);
+}
+
+export function *distinctSync<T>(iterable: Iterable<T>): IterableIterator<T> {
     const seen = new Set<T>();
-    for await (const element of iterable) {
+    for (const element of iterable) {
         if (!seen.has(element)) {
             yield element;
             seen.add(element);
         }
+    }
+}
+
+class Deduplicator<T> implements AsyncIterableIterator<T> {
+    private readonly iterator: AsyncIterator<T>;
+    private readonly seen = new Set<T>();
+
+    constructor(iterable: AsyncIterable<T>) {
+        this.iterator = iterable[Symbol.asyncIterator]();
+    }
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    next(): Promise<IteratorResult<T>> {
+        return this.iterator.next().then(({done, value}) => {
+            if (done) {
+                return {done, value};
+            }
+
+            if (this.seen.has(value)) {
+                return this.next();
+            } else {
+                this.seen.add(value);
+                return {done, value};
+            }
+        })
+    }
+
+    return(): Promise<IteratorResult<T>> {
+        if (typeof this.iterator.return === 'function') {
+            return this.iterator.return();
+        }
+
+        return Promise.resolve({done: true} as IteratorResult<T>);
     }
 }

--- a/src/distinct.ts
+++ b/src/distinct.ts
@@ -8,6 +8,14 @@ import { isSyncIterable } from './isIterable';
  * i.e., it is evaluated via the [`SameValueZero` algorithm](http://www.ecma-international.org/ecma-262/6.0/#sec-samevaluezero)
  * described in the ECMAScript 2015 specification.
  */
+export function distinct<T>(iterable: Iterable<T>): Iterable<T>;
+
+export function distinct<T>(iterable: AsyncIterable<T>): AsyncIterable<T>;
+
+export function distinct<T>(
+    iterable: Iterable<T>|AsyncIterable<T>
+): Iterable<T>|AsyncIterable<T>;
+
 export function distinct<T>(
     iterable: Iterable<T>|AsyncIterable<T>
 ): Iterable<T>|AsyncIterable<T> {

--- a/src/every.spec.ts
+++ b/src/every.spec.ts
@@ -1,9 +1,13 @@
 import { every, range } from '.';
-import { asyncify } from './testIterators.fixture';
+import {
+    AsyncFibonacciSequence,
+    asyncify,
+    CloseHandlingIterator,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('every', async t => {
-    t.plan(4)
+    t.plan(6)
 
     const allEvens = every.bind(null, (num: number) => num % 2 === 0)
 
@@ -14,4 +18,14 @@ test('every', async t => {
     t.equal(true, await allEvens(asyncify(range(0, 10, 2))))
 
     t.equal(false, await allEvens(asyncify(range(0, 10))))
+
+    const iter = new CloseHandlingIterator;
+    await every(() => false, iter);
+    t.ok(
+        iter.returnCalled,
+        '.return should be called on the underlying iterator when an element does not satisfy the predicate an early exit'
+    );
+
+    await every(() => false, new AsyncFibonacciSequence)
+    t.pass('should handle early termination of iterators with no defined .return method')
 })

--- a/src/every.ts
+++ b/src/every.ts
@@ -7,10 +7,25 @@ import { isSyncIterable } from './isIterable';
  * @param predicate A function that takes an element yielded by the provided
  *                  iterable and returns a boolean.
  */
-export async function every<T>(
+export function every<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>
+): boolean;
+
+export function every<T>(
+    predicate: (arg: T) => boolean,
+    iterable: AsyncIterable<T>
+): Promise<boolean>;
+
+export function every<T>(
     predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
-): Promise<boolean> {
+): Promise<boolean>;
+
+export function every<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>|AsyncIterable<T>
+): boolean|Promise<boolean> {
     if (isSyncIterable(iterable)) {
         return everySync(predicate, iterable);
     }

--- a/src/every.ts
+++ b/src/every.ts
@@ -7,25 +7,10 @@ import { isSyncIterable } from './isIterable';
  * @param predicate A function that takes an element yielded by the provided
  *                  iterable and returns a boolean.
  */
-export function every<T>(
-    predicate: (arg: T) => boolean,
-    iterable: Iterable<T>
-): boolean;
-
-export function every<T>(
-    predicate: (arg: T) => boolean,
-    iterable: AsyncIterable<T>
-): Promise<boolean>;
-
-export function every<T>(
+export async function every<T>(
     predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
-): Promise<boolean>;
-
-export function every<T>(
-    predicate: (arg: T) => boolean,
-    iterable: Iterable<T>|AsyncIterable<T>
-): boolean|Promise<boolean> {
+): Promise<boolean> {
     if (isSyncIterable(iterable)) {
         return everySync(predicate, iterable);
     }

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -9,7 +9,7 @@ test('filter retains all elements that satisfy the predicate and discards the re
 
     t.deepEqual(
         [2, 8, 34],
-        await collect(filterEvens(take(10, fibonacci())))
+        [...filterEvens(take(10, fibonacci()))]
     )
 
     t.deepEqual(
@@ -23,7 +23,7 @@ test('filter is applied lazily', async t => {
 
     t.deepEqual(
         [2, 8, 34, 144, 610],
-        await collect(take(5, filterEvens(fibonacci())))
+        [...take(5, filterEvens(fibonacci()) as IterableIterator<number>)]
     )
 
     t.deepEqual(

--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -1,5 +1,5 @@
 import { collect, filter, take } from '.';
-import { asyncFibonacci, fibonacci } from './testIterators.fixture';
+import { asyncFibonacci, fibonacci, DECORATOR_ERROR_TEST_COUNT, testDecoratorErrorHandling } from './testIterators.fixture';
 import * as test from 'tape';
 
 const filterEvens = filter.bind(null, (num: number) => num % 2 === 0)
@@ -30,4 +30,10 @@ test('filter is applied lazily', async t => {
         [2, 8, 34, 144, 610],
         await collect(take(5, filterEvens(asyncFibonacci())))
     )
+})
+
+test('filter error handling', async t => {
+    t.plan(DECORATOR_ERROR_TEST_COUNT)
+
+    await testDecoratorErrorHandling(filter.bind(null, () => true), t, 'filter')
 })

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -11,6 +11,21 @@ import { isSyncIterable } from './isIterable';
  */
 export function filter<T>(
     predicate: (arg: T) => boolean,
+    iterable: Iterable<T>
+): IterableIterator<T>;
+
+export function filter<T>(
+    predicate: (arg: T) => boolean,
+    iterable: AsyncIterable<T>
+): AsyncIterableIterator<T>;
+
+export function filter<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<T>|AsyncIterableIterator<T>;
+
+export function filter<T>(
+    predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
 ): IterableIterator<T>|AsyncIterableIterator<T> {
     if (isSyncIterable(iterable)) {

--- a/src/find.spec.ts
+++ b/src/find.spec.ts
@@ -1,21 +1,43 @@
 import { find, range } from '.';
-import { asyncFibonacci } from './testIterators.fixture';
+import {
+    AsyncFibonacciSequence,
+    asyncify,
+    CloseHandlingIterator,
+    fibonacci,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('find', async t => {
-    t.plan(2)
+    t.plan(5)
 
     t.equal(
         144,
-        await find((num: number) => num % 12 === 0, asyncFibonacci()),
+        await find((num: number) => num % 12 === 0, fibonacci()),
         'finds elements in infinite sequences'
+    )
+
+    t.equal(
+        144,
+        await find((num: number) => num % 12 === 0, new AsyncFibonacciSequence()),
+        'finds elements in infinite async sequences'
+    )
+
+    const iter = new CloseHandlingIterator
+    await find(() => true, iter);
+    t.ok(
+        iter.returnCalled,
+        'calls .return on the underlying iterator when a match is found'
     )
 
     try {
         await find((num: number) => num > 100, range(5))
-        t.fail('should have thrown when no sequence member satisfying the predicate could be found')
     } catch {
         t.pass('throws when no sequence members satisfy the predicate')
     }
 
+    try {
+        await find((num: number) => num > 100, asyncify(range(5)))
+    } catch {
+        t.pass('throws when no async sequence members satisfy the predicate')
+    }
 })

--- a/src/find.ts
+++ b/src/find.ts
@@ -5,28 +5,12 @@ import { isSyncIterable } from './isIterable';
  * supplied predicate.
  *
  * @param predicate A function that takes an element yielded by the provided
- *                  iterable and returns a boolean or a promise that resolves to
- *                  a boolean.
+ *                  iterable and returns a boolean.
  */
-export function find<T>(
-    predicate: (arg: T) => boolean,
-    iterable: Iterable<T>
-): T;
-
-export function find<T>(
-    predicate: (arg: T) => boolean,
-    iterable: AsyncIterable<T>
-): Promise<T>;
-
-export function find<T>(
+export async function find<T>(
     predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
-): T|Promise<T>;
-
-export function find<T>(
-    predicate: (arg: T) => boolean,
-    iterable: Iterable<T>|AsyncIterable<T>
-): T|Promise<T> {
+): Promise<T> {
     if (isSyncIterable(iterable)) {
         return findSync(predicate, iterable);
     }

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,3 +1,5 @@
+import { isSyncIterable } from './isIterable';
+
 /**
  * Locates the first value yielded by the supplied iterable that satisfies the
  * supplied predicate.
@@ -7,12 +9,48 @@
  *                  a boolean.
  */
 export async function find<T>(
-    predicate: (arg: T) => boolean|Promise<boolean>,
+    predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
 ) {
-    for await (const element of iterable) {
-        if (await predicate(element)) {
+    if (isSyncIterable(iterable)) {
+        return findSync(predicate, iterable);
+    }
+
+    return findAsync(predicate, iterable);
+}
+
+export function findSync<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>
+): T {
+    for (const element of iterable) {
+        if (predicate(element)) {
             return element;
+        }
+    }
+
+    throw new Error('No yielded value satisfied the provided condition');
+}
+
+async function findAsync<T>(
+    predicate: (arg: T) => boolean,
+    iterable: AsyncIterable<T>
+): Promise<T> {
+    const iterator = iterable[Symbol.asyncIterator]();
+    for (
+        let next = await iterator.next(),
+            value = next.value,
+            done = next.done;
+        !done;
+        next = await iterator.next(),
+        value = next.value,
+        done = next.done
+    ) {
+        if (predicate(value)) {
+            if (typeof iterator.return === 'function') {
+                await iterator.return();
+            }
+            return value;
         }
     }
 

--- a/src/find.ts
+++ b/src/find.ts
@@ -8,10 +8,25 @@ import { isSyncIterable } from './isIterable';
  *                  iterable and returns a boolean or a promise that resolves to
  *                  a boolean.
  */
-export async function find<T>(
+export function find<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>
+): T;
+
+export function find<T>(
+    predicate: (arg: T) => boolean,
+    iterable: AsyncIterable<T>
+): Promise<T>;
+
+export function find<T>(
     predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
-) {
+): T|Promise<T>;
+
+export function find<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>|AsyncIterable<T>
+): T|Promise<T> {
     if (isSyncIterable(iterable)) {
         return findSync(predicate, iterable);
     }

--- a/src/flatten.spec.ts
+++ b/src/flatten.spec.ts
@@ -1,9 +1,13 @@
 import { collect, flatten } from '.';
-import { asyncify } from './testIterators.fixture';
+import {
+    asyncify,
+    DECORATOR_ERROR_TEST_COUNT,
+    testDecoratorErrorHandling
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('flatten', async t => {
-    t.plan(3)
+    t.plan(4 + DECORATOR_ERROR_TEST_COUNT)
 
     t.deepEqual(
         await collect(flatten(asyncify([[0], [1, 2], 3]))),
@@ -25,4 +29,12 @@ test('flatten', async t => {
         ['an', 'iterable', 'of', 'strings'],
         'does not flatten strings'
     )
+
+    t.deepEqual(
+        await collect(flatten(Infinity, [{foo: 'bar'}])),
+        [{foo: 'bar'}],
+        'should yield uniterable objects'
+    )
+
+    testDecoratorErrorHandling(flatten, t, 'flatten')
 })

--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,4 +1,5 @@
 import { isSyncIterable, isAsyncIterable } from './isIterable';
+import { iteratorFromIterable } from './iteratorFromIterable';
 
 /**
  * A synchronous iterable whose elements are either of type T or are themselves
@@ -172,11 +173,7 @@ class FlattenIterator<T> {
         private readonly depth: number,
         iterable: Iterable<T>|AsyncIterable<T>
     ) {
-        this.iteratorStack.push(
-            isSyncIterable(iterable)
-                ? iterable[Symbol.iterator]()
-                : iterable[Symbol.asyncIterator]()
-        );
+        this.iteratorStack.push(iteratorFromIterable(iterable));
     }
 
     [Symbol.asyncIterator]() {

--- a/src/includes.spec.ts
+++ b/src/includes.spec.ts
@@ -1,5 +1,5 @@
 import { range, includes } from '.';
-import { asyncify } from './testIterators.fixture';
+import { asyncify, AsyncFibonacciSequence } from './testIterators.fixture';
 import * as test from 'tape';
 
 test('includes', async t => {
@@ -26,7 +26,7 @@ test('includes', async t => {
         ],
     ];
 
-    t.plan(testCases.length)
+    t.plan(testCases.length + 1)
 
     for (const [iterable, searchElement, expectedResult] of testCases) {
         t.equal(
@@ -34,4 +34,10 @@ test('includes', async t => {
             expectedResult
         )
     }
+
+    t.equal(
+        await includes(34, new AsyncFibonacciSequence),
+        true,
+        'should handle terminating async iterators with no defined .return method'
+    )
 })

--- a/src/includes.ts
+++ b/src/includes.ts
@@ -1,3 +1,5 @@
+import { isSyncIterable } from './isIterable';
+
 /**
  * Determines if any of the values yielded by the supplied iterator are equal to
  * (`===`) a particular value.
@@ -9,8 +11,36 @@ export async function includes<T>(
     searchElement: T,
     iterable: Iterable<T>|AsyncIterable<T>
 ) {
-    for await (const element of iterable) {
+    return isSyncIterable(iterable)
+        ? includesSync(searchElement, iterable)
+        : includesAsync(searchElement, iterable);
+}
+
+export function includesSync<T>(searchElement: T, iterable: Iterable<T>) {
+    for (const element of iterable) {
         if (element === searchElement) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+async function includesAsync<T>(searchElement: T, iterable: AsyncIterable<T>) {
+    const iterator = iterable[Symbol.asyncIterator]();
+    for (
+        let next = await iterator.next(),
+            value = next.value,
+            done = next.done;
+        !done;
+        next = await iterator.next(),
+        value = next.value,
+        done = next.done
+    ) {
+        if (value === searchElement) {
+            if (typeof iterator.return === 'function') {
+                await iterator.return();
+            }
             return true;
         }
     }

--- a/src/interleave.ts
+++ b/src/interleave.ts
@@ -1,4 +1,4 @@
-import { isSyncIterable } from './isIterable';
+import { iteratorFromIterable } from './iteratorFromIterable';
 
 /**
  * Mix zero or more synchronous or asynchronous iterables by alternating between
@@ -24,12 +24,9 @@ class InterleavingIterator<T> implements AsyncIterableIterator<T> {
 
     async next(): Promise<IteratorResult<T>> {
         if (this.sourceIterables.length > 0) {
-            const iterable = this.sourceIterables.shift() as Iterable<T>|AsyncIterable<T>;
-            this.iterators.push(
-                isSyncIterable(iterable)
-                    ? iterable[Symbol.iterator]()
-                    : iterable[Symbol.asyncIterator]()
-            );
+            this.iterators.push(iteratorFromIterable(
+                this.sourceIterables.shift() as Iterable<T>|AsyncIterable<T>
+            ));
         }
 
         if (this.iterators.length === 0) {

--- a/src/interleave.ts
+++ b/src/interleave.ts
@@ -1,37 +1,69 @@
-import { iteratorFromIterable } from './iteratorFromIterable';
+import { isSyncIterable } from './isIterable';
 
 /**
  * Mix zero or more synchronous or asynchronous iterables by alternating between
  * them.
  */
-export async function *interleave<T>(
+export function interleave<T>(
     ...iterables: Array<Iterable<T>|AsyncIterable<T>>
-) {
-    const cursors = new Map<
-        Iterator<T>|AsyncIterator<T>,
-        IteratorResult<T>|Promise<IteratorResult<T>>
-    >(function *() {
-        for (const iterable of iterables) {
-            const iterator = iteratorFromIterable(iterable);
-            yield [iterator, iterator.next()] as [
-                Iterator<T>|AsyncIterator<T>,
-                IteratorResult<T>|Promise<IteratorResult<T>>
-            ];
-        }
-    }());
+): AsyncIterableIterator<T> {
+    return new InterleavingIterator(iterables);
+}
 
-    while (cursors.size > 0) {
-        for (const [iterator, result] of cursors) {
-            const {value, done} = await result;
-            if (!done || value !== undefined) {
-                yield value;
-            }
+class InterleavingIterator<T> implements AsyncIterableIterator<T> {
+    private current = 0
+    private readonly iterators: Array<Iterator<T>|AsyncIterator<T>> = []
 
-            if (done) {
-                cursors.delete(iterator);
-            } else {
-                cursors.set(iterator, iterator.next());
+    constructor(
+        private readonly sourceIterables: Array<Iterable<T>|AsyncIterable<T>>
+    ) {}
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    async next(): Promise<IteratorResult<T>> {
+        if (this.sourceIterables.length > 0) {
+            const iterable = this.sourceIterables.shift() as Iterable<T>|AsyncIterable<T>;
+            this.iterators.push(
+                isSyncIterable(iterable)
+                    ? iterable[Symbol.iterator]()
+                    : iterable[Symbol.asyncIterator]()
+            );
+        }
+
+        if (this.iterators.length === 0) {
+            return { done: true } as IteratorResult<T>;
+        }
+
+        const { done, value } = await this.iterators[this.current].next();
+        if (done) {
+            this.iterators.splice(this.current, 1);
+            if (this.current === this.iterators.length) {
+                this.current = 0
+            }
+            return this.next();
+        }
+
+        if (
+            ++this.current >= this.iterators.length &&
+            this.sourceIterables.length === 0
+        ) {
+            this.current = 0
+        }
+
+        return { done, value };
+    }
+
+    async return(): Promise<IteratorResult<T>> {
+        this.sourceIterables.length = 0;
+        let iterator: Iterator<T>|AsyncIterator<T>|undefined;
+        while (iterator = this.iterators.pop()) {
+            if (typeof iterator.return === 'function') {
+                await iterator.return();
             }
         }
+
+        return { done: true } as IteratorResult<T>;
     }
 }

--- a/src/isIterable.ts
+++ b/src/isIterable.ts
@@ -2,10 +2,6 @@ export function isAsyncIterable<T>(arg: any): arg is AsyncIterable<T> {
     return Boolean(arg) && typeof arg[Symbol.asyncIterator] === 'function';
 }
 
-export function isIterable<T>(arg: any): arg is Iterable<T>|AsyncIterable<T> {
-    return isAsyncIterable(arg) || isSyncIterable(arg);
-}
-
 export function isSyncIterable<T>(arg: any): arg is Iterable<T> {
     return Boolean(arg) && typeof arg[Symbol.iterator] === 'function';
 }

--- a/src/iteratorFromIterable.ts
+++ b/src/iteratorFromIterable.ts
@@ -1,11 +1,11 @@
 import { isAsyncIterable } from './isIterable';
 
 export function iteratorFromIterable<T>(
-    iterable?: Iterable<T>|AsyncIterable<T>
+    iterable: Iterable<T>|AsyncIterable<T>
 ): Iterator<T>|AsyncIterator<T> {
     if (isAsyncIterable(iterable)) {
         return iterable[Symbol.asyncIterator]();
     }
 
-    return (iterable as Iterable<T>)[Symbol.iterator]();
+    return iterable[Symbol.iterator]();
 }

--- a/src/map.spec.ts
+++ b/src/map.spec.ts
@@ -1,5 +1,9 @@
 import { collect, map, range } from '.';
-import { asyncify } from './testIterators.fixture';
+import {
+    asyncify,
+    DECORATOR_ERROR_TEST_COUNT,
+    testDecoratorErrorHandling,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('map', async t => {
@@ -25,7 +29,7 @@ test('map', async t => {
         ],
     ];
 
-    t.plan(testCases.length)
+    t.plan(testCases.length + DECORATOR_ERROR_TEST_COUNT)
 
     for (const [iterable, predicate, expected] of testCases) {
         t.deepEqual(
@@ -33,4 +37,6 @@ test('map', async t => {
             expected
         )
     }
+
+    testDecoratorErrorHandling(map.bind(null, (val: any) => val), t, 'map')
 })

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,3 +1,6 @@
+import { AsyncIterableDecorator } from './AsyncIterableDecorator';
+import { isSyncIterable } from './isIterable';
+
 /**
  * Transforms each value yielded by the supplied iterable by calling the
  * supplied and returning the result.
@@ -5,11 +8,38 @@
  * @param f The function to call with each value yielded by the provided
  *          iterable.
  */
-export async function *map<T, R>(
+export function map<T, R>(
     f: (arg: T) => R,
     iterable: Iterable<T>|AsyncIterable<T>
-): AsyncIterableIterator<R> {
-    for await (const element of iterable) {
+): IterableIterator<R>|AsyncIterableIterator<R> {
+    if (isSyncIterable(iterable)) {
+        return mapSync(f, iterable);
+    }
+
+    return new MapIterator(f, iterable);
+}
+
+export function *mapSync<T, R>(f: (arg: T) => R, iterable: Iterable<T>) {
+    for (const element of iterable) {
         yield f(element);
+    }
+}
+
+class MapIterator<T, R> extends AsyncIterableDecorator<R> {
+    constructor(
+        private readonly f: (arg: T) => R,
+        iterable: AsyncIterable<T>
+    ) {
+        super(iterable as any);
+    }
+
+    next(): Promise<IteratorResult<R>> {
+        return this.iterator.next().then(({done, value}: any) => {
+            if (done) {
+                return { done } as IteratorResult<R>;
+            }
+
+            return { done, value: this.f(value) };
+        })
     }
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -48,13 +48,12 @@ class MapIterator<T, R> extends AsyncIterableDecorator<R> {
         super(iterable as any);
     }
 
-    next(): Promise<IteratorResult<R>> {
-        return this.iterator.next().then(({done, value}: any) => {
+    async next(): Promise<IteratorResult<R>> {
+        const {done, value} = await this.iterator.next();
             if (done) {
                 return { done } as IteratorResult<R>;
             }
 
-            return { done, value: this.f(value) };
-        })
+        return { done, value: this.f(value as any) };
     }
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -10,6 +10,21 @@ import { isSyncIterable } from './isIterable';
  */
 export function map<T, R>(
     f: (arg: T) => R,
+    iterable: Iterable<T>
+): IterableIterator<R>;
+
+export function map<T, R>(
+    f: (arg: T) => R,
+    iterable: AsyncIterable<T>
+): AsyncIterableIterator<R>;
+
+export function map<T, R>(
+    f: (arg: T) => R,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<R>|AsyncIterableIterator<R>;
+
+export function map<T, R>(
+    f: (arg: T) => R,
     iterable: Iterable<T>|AsyncIterable<T>
 ): IterableIterator<R>|AsyncIterableIterator<R> {
     if (isSyncIterable(iterable)) {

--- a/src/merge.spec.ts
+++ b/src/merge.spec.ts
@@ -1,8 +1,23 @@
 import { collect, merge } from '.';
+import {
+    DECORATOR_ERROR_TEST_COUNT,
+    testDecoratorErrorHandling,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('merge', async t => {
-    t.plan(2)
+    t.plan(3 + DECORATOR_ERROR_TEST_COUNT)
+
+    t.deepEqual(
+        await collect(merge(
+            [0, 4, 7, 9],
+            [1, 5, 8],
+            [2, 6],
+            [3],
+        )),
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        'should yield from synchronous iterators in the order in which they were received'
+    )
 
     t.deepEqual(
         await collect(merge(
@@ -47,5 +62,7 @@ test('merge', async t => {
         )),
         [0, 1, 2, 3],
         'should prioritize elements yielded by iterables provided first in the arguments'
-    )
+    );
+
+    testDecoratorErrorHandling(merge, t, 'merge');
 })

--- a/src/reduce.ts
+++ b/src/reduce.ts
@@ -1,3 +1,5 @@
+import { iteratorFromIterable } from './iteratorFromIterable';
+
 /**
  * Reduces an iterable to a single value by applying the provided `reducer`
  * function against an accumulator and each element yielded by the iterable (in
@@ -38,7 +40,16 @@ export async function reduce<T, R>(
         initialized = false;
     }
 
-    for await (const element of iterable) {
+    const iterator = iteratorFromIterable(iterable);
+    for (
+        let next = await iterator.next(),
+            element = next.value,
+            done = next.done;
+        !done;
+        next = await iterator.next(),
+        element = next.value,
+        done = next.done
+    ) {
         if (initialized) {
             value = await reducer(value, element);
         } else {

--- a/src/skip.spec.ts
+++ b/src/skip.spec.ts
@@ -1,5 +1,9 @@
 import { collect, range, skip } from '.';
-import { asyncify } from './testIterators.fixture';
+import {
+    asyncify,
+    DECORATOR_ERROR_TEST_COUNT,
+    testDecoratorErrorHandling,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('skip', async t => {
@@ -30,9 +34,11 @@ test('skip', async t => {
         ],
     ];
 
-    t.plan(testCases.length)
+    t.plan(testCases.length + DECORATOR_ERROR_TEST_COUNT);
 
     for (const [toSkip, iterable, expected] of testCases) {
         t.deepEqual(await collect(skip(toSkip, iterable)), expected)
     }
+
+    testDecoratorErrorHandling(skip.bind(null, 10), t, 'skip');
 })

--- a/src/skip.ts
+++ b/src/skip.ts
@@ -1,17 +1,52 @@
+import { AsyncIterableDecorator } from './AsyncIterableDecorator';
+import { isSyncIterable } from './isIterable';
+
 /**
  * Creates an asynchronous iterable of all but the first `toSkip` items in the
  * provided iterable.
  *
  * @param toSkip    The number of values from the underlying iterable to skip.
  */
-export async function *skip<T>(
+export function skip<T>(
     toSkip: number,
     iterable: Iterable<T>|AsyncIterable<T>
-) {
+): IterableIterator<T>|AsyncIterableIterator<T> {
+    if (isSyncIterable(iterable)) {
+        return skipSync(toSkip, iterable);
+    }
+
+    return new SkipIterator(toSkip, iterable);
+}
+
+export function *skipSync<T>(toSkip: number, iterable: Iterable<T>) {
     let index = 0;
-    for await (const element of iterable) {
+    for (const element of iterable) {
         if (++index > toSkip) {
             yield element;
         }
+    }
+}
+
+class SkipIterator<T> extends AsyncIterableDecorator<T> {
+    private index = 0
+
+    constructor(
+        private readonly toSkip: number,
+        iterable: AsyncIterable<T>
+    ) {
+        super(iterable);
+    }
+
+    async next(): Promise<IteratorResult<T>> {
+        const {value, done} = await this.iterator.next();
+        if (done) {
+            return { done, value };
+        }
+
+        if (++this.index > this.toSkip) {
+            return { done, value };
+        }
+
+        return this.next();
     }
 }

--- a/src/skip.ts
+++ b/src/skip.ts
@@ -9,6 +9,21 @@ import { isSyncIterable } from './isIterable';
  */
 export function skip<T>(
     toSkip: number,
+    iterable: Iterable<T>
+): IterableIterator<T>;
+
+export function skip<T>(
+    toSkip: number,
+    iterable: AsyncIterable<T>
+): AsyncIterableIterator<T>;
+
+export function skip<T>(
+    toSkip: number,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<T>|AsyncIterableIterator<T>;
+
+export function skip<T>(
+    toSkip: number,
     iterable: Iterable<T>|AsyncIterable<T>
 ): IterableIterator<T>|AsyncIterableIterator<T> {
     if (isSyncIterable(iterable)) {

--- a/src/skipWhile.spec.ts
+++ b/src/skipWhile.spec.ts
@@ -1,5 +1,9 @@
 import { collect, skipWhile } from '.';
-import { asyncify } from './testIterators.fixture';
+import {
+    asyncify,
+    DECORATOR_ERROR_TEST_COUNT,
+    testDecoratorErrorHandling,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('skipWhile', async t => {
@@ -30,9 +34,11 @@ test('skipWhile', async t => {
         ],
     ];
 
-    t.plan(testCases.length)
+    t.plan(testCases.length + DECORATOR_ERROR_TEST_COUNT)
 
     for (const [predicate, iterable, expected] of testCases) {
         t.deepEqual(await collect(skipWhile(predicate, iterable)), expected)
     }
+
+    testDecoratorErrorHandling(skipWhile.bind(null, () => false), t, 'skipWhile');
 })

--- a/src/skipWhile.spec.ts
+++ b/src/skipWhile.spec.ts
@@ -8,7 +8,7 @@ import * as test from 'tape';
 
 test('skipWhile', async t => {
     const testCases: Array<[
-        (arg: number) => boolean|Promise<boolean>,
+        (arg: number) => boolean,
         Iterable<number>|AsyncIterable<number>,
         Array<number>
     ]> = [
@@ -18,17 +18,7 @@ test('skipWhile', async t => {
             [10, 9],
         ],
         [
-            (arg: number) => Promise.resolve(arg < 10),
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9],
-            [10, 9],
-        ],
-        [
             (arg: number) => arg < 10,
-            asyncify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9]),
-            [10, 9],
-        ],
-        [
-            (arg: number) => Promise.resolve(arg < 10),
             asyncify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9]),
             [10, 9],
         ],

--- a/src/skipWhile.ts
+++ b/src/skipWhile.ts
@@ -11,6 +11,21 @@ import { isSyncIterable } from './isIterable';
  */
 export function skipWhile<T>(
     predicate: (arg: T) => boolean,
+    iterable: Iterable<T>
+): IterableIterator<T>;
+
+export function skipWhile<T>(
+    predicate: (arg: T) => boolean,
+    iterable: AsyncIterable<T>
+): AsyncIterableIterator<T>;
+
+export function skipWhile<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<T>|AsyncIterableIterator<T>;
+
+export function skipWhile<T>(
+    predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
 ): IterableIterator<T>|AsyncIterableIterator<T> {
     if (isSyncIterable(iterable)) {

--- a/src/skipWhile.ts
+++ b/src/skipWhile.ts
@@ -1,3 +1,5 @@
+import { iteratorFromIterable } from './iteratorFromIterable';
+
 /**
  * Creates an asynchronous iterable of all but the first items in the provided
  * iterable for which the provided predicate returns true. Once the predicate
@@ -7,14 +9,46 @@
  *                  iterable and returns a boolean or a promise that resolves to
  *                  a boolean.
  */
-export async function *skipWhile<T>(
+export function skipWhile<T>(
     predicate: (arg: T) => boolean|Promise<boolean>,
     iterable: Iterable<T>|AsyncIterable<T>
-) {
-    let satisfied = true;
-    for await (const element of iterable) {
-        if (!satisfied || !(satisfied = await predicate(element))) {
-            yield element;
+): AsyncIterableIterator<T> {
+    return new SkipWhileIterator(predicate, iterable);
+}
+
+class SkipWhileIterator<T> implements AsyncIterableIterator<T> {
+    private readonly iterator: Iterator<T>|AsyncIterator<T>;
+    private satisfied = true
+
+    constructor(
+        private readonly predicate: (arg: T) => boolean|Promise<boolean>,
+        iterable: Iterable<T>|AsyncIterable<T>
+    ) {
+        this.iterator = iteratorFromIterable(iterable);
+    }
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    async next(): Promise<IteratorResult<T>> {
+        const {value, done} = await this.iterator.next();
+        if (done) {
+            return { done, value };
         }
+
+        if (!this.satisfied || !(this.satisfied = await this.predicate(value))) {
+            return { done, value };
+        }
+
+        return this.next();
+    }
+
+    async return(): Promise<IteratorResult<T>> {
+        if (typeof this.iterator.return === 'function') {
+            return this.iterator.return();
+        }
+
+        return { done: true } as IteratorResult<T>;
     }
 }

--- a/src/some.spec.ts
+++ b/src/some.spec.ts
@@ -5,12 +5,12 @@ import * as test from 'tape';
 test('some', async t => {
     const testCases: Array<[
         Iterable<number>|AsyncIterable<number>,
-        (arg: number) => boolean|Promise<boolean>,
+        (arg: number) => boolean,
         boolean
     ]> = [
         [
             range(1, 10),
-            (num: number) => Promise.resolve(num % 2 === 0),
+            (num: number) => num % 2 === 0,
             true,
         ],
         [
@@ -25,7 +25,7 @@ test('some', async t => {
         ],
         [
             asyncify(range(1, 10, 2)),
-            (num: number) => Promise.resolve(num % 2 === 0),
+            (num: number) => num % 2 === 0,
             false,
         ],
     ];

--- a/src/some.spec.ts
+++ b/src/some.spec.ts
@@ -1,5 +1,5 @@
 import { range, some } from '.';
-import { asyncify } from './testIterators.fixture';
+import { asyncify, AsyncFibonacciSequence } from './testIterators.fixture';
 import * as test from 'tape';
 
 test('some', async t => {
@@ -30,9 +30,15 @@ test('some', async t => {
         ],
     ];
 
-    t.plan(testCases.length)
+    t.plan(testCases.length + 1)
 
     for (const [iterable, predicate, expected] of testCases) {
         t.equal(await some(predicate, iterable), expected)
     }
+
+    t.equal(
+        await some(() => true, new AsyncFibonacciSequence),
+        true,
+        'should handle terminating async iterators with no defined .return method'
+    )
 })

--- a/src/some.ts
+++ b/src/some.ts
@@ -1,3 +1,5 @@
+import { iteratorFromIterable } from './iteratorFromIterable';
+
 /**
  * Determines if any value yielded by the provided iterable satisfies the
  * provided predicate.
@@ -10,8 +12,21 @@ export async function some<T>(
     predicate: (arg: T) => boolean|Promise<boolean>,
     iterable: Iterable<T>|AsyncIterable<T>
 ) {
-    for await (const element of iterable) {
+    for (
+        let iterator = iteratorFromIterable(iterable),
+            next = await iterator.next(),
+            element = next.value,
+            done = next.done;
+        !done;
+        next = await iterator.next(),
+        element = next.value,
+        done = next.done
+    ) {
         if (await predicate(element)) {
+            if (typeof iterator.return === 'function') {
+                await iterator.return();
+            }
+
             return true;
         }
     }

--- a/src/sum.ts
+++ b/src/sum.ts
@@ -1,12 +1,36 @@
+import { isAsyncIterable } from './isIterable';
+
 /**
  * @returns the sum of all values yielded by the provided `iterable`.
  */
 export async function sum(
     iterable: Iterable<number>|AsyncIterable<number>
 ): Promise<number> {
+    if (isAsyncIterable(iterable)) {
+        return sumAsync(iterable);
+    }
+
+    return sumSync(iterable);
+}
+
+export function sumSync(iterable: Iterable<number>): number {
     let sum = 0;
-    for await (const element of iterable) {
+    for (const element of iterable) {
         sum += element;
+    }
+
+    return sum;
+}
+
+async function sumAsync(iterable: AsyncIterable<number>): Promise<number> {
+    let sum = 0
+    for (
+        let iterator = iterable[Symbol.asyncIterator](),
+            next = await iterator.next();
+        !next.done;
+        next = await iterator.next()
+    ) {
+        sum += next.value;
     }
 
     return sum;

--- a/src/take.spec.ts
+++ b/src/take.spec.ts
@@ -24,6 +24,8 @@ test('take', async t => {
 
     t.plan(testCases.length);
 
+    take(2, [1, 2, 3]);
+
     for (const [limit, iterable] of testCases) {
         let count = 0
         for await (const _ of take(limit, iterable)) {

--- a/src/take.spec.ts
+++ b/src/take.spec.ts
@@ -1,5 +1,5 @@
 import { range, repeat, take } from '.';
-import { asyncify, throwOnIteration } from './testIterators.fixture';
+import { asyncify, ExplosiveIterator } from './testIterators.fixture';
 import * as test from 'tape';
 
 test('take', async t => {
@@ -8,7 +8,7 @@ test('take', async t => {
         [10, asyncify(repeat('foo'))],
         [10, range(5)],
         [10, asyncify(range(5))],
-        [0, throwOnIteration()],
+        [0, new ExplosiveIterator()],
     ];
 
     t.plan(testCases.length)

--- a/src/take.spec.ts
+++ b/src/take.spec.ts
@@ -1,5 +1,10 @@
 import { range, repeat, take } from '.';
-import { asyncify, ExplosiveIterator } from './testIterators.fixture';
+import {
+    asyncify,
+    DECORATOR_ERROR_TEST_COUNT,
+    ExplosiveIterator,
+    testDecoratorErrorHandling,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('take', async t => {
@@ -9,9 +14,15 @@ test('take', async t => {
         [10, range(5)],
         [10, asyncify(range(5))],
         [0, new ExplosiveIterator()],
+        [
+            0,
+            (function *(): IterableIterator<never> {
+                throw new Error('PANIC');
+            })(),
+        ],
     ];
 
-    t.plan(testCases.length)
+    t.plan(testCases.length);
 
     for (const [limit, iterable] of testCases) {
         let count = 0
@@ -22,6 +33,13 @@ test('take', async t => {
         t.assert(
             count <= limit,
             `should fetch at most ${limit} elements from the source iterable`
-        )
+        );
     }
 })
+
+test('take error handling', async t => {
+
+    t.plan(DECORATOR_ERROR_TEST_COUNT);
+
+    testDecoratorErrorHandling(take.bind(null, 5), t, 'take');
+});

--- a/src/take.ts
+++ b/src/take.ts
@@ -1,18 +1,49 @@
+import { AsyncIterableDecorator } from './AsyncIterableDecorator';
+import { isSyncIterable } from './isIterable';
+
 /**
  * Returns a lazy sequence of the first `limit` items in the provided iterable,
  * or all items if there are fewer than `limit`.
  *
  * @param limit The maximum number of items to return.
  */
-export async function *take<T>(
+export function take<T>(
     limit: number,
     iterable: Iterable<T>|AsyncIterable<T>
-) {
+): IterableIterator<T>|AsyncIterableIterator<T> {
+    if (isSyncIterable(iterable)) {
+        return takeSync(limit, iterable);
+    }
+
+    return new TakeIterator(limit, iterable);
+}
+
+export function *takeSync<T>(limit: number, iterable: Iterable<T>) {
     if (limit <= 0) return;
 
     let i = 0;
-    for await (const element of iterable) {
+    for (const element of iterable) {
         yield element;
         if (++i >= limit) break;
+    }
+}
+
+
+class TakeIterator<T> extends AsyncIterableDecorator<T> {
+    private index = 0
+
+    constructor(
+        private readonly toTake: number,
+        iterable: AsyncIterable<T>
+    ) {
+        super(iterable);
+    }
+
+    async next(): Promise<IteratorResult<T>> {
+        if (++this.index > this.toTake) {
+            return this.return();
+        }
+
+        return this.iterator.next();
     }
 }

--- a/src/take.ts
+++ b/src/take.ts
@@ -9,6 +9,21 @@ import { isSyncIterable } from './isIterable';
  */
 export function take<T>(
     limit: number,
+    iterable: AsyncIterable<T>
+): AsyncIterableIterator<T>;
+
+export function take<T>(
+    limit: number,
+    iterable: Iterable<T>
+): IterableIterator<T>;
+
+export function take<T>(
+    limit: number,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<T>|AsyncIterableIterator<T>;
+
+export function take<T>(
+    limit: number,
     iterable: Iterable<T>|AsyncIterable<T>
 ): IterableIterator<T>|AsyncIterableIterator<T> {
     if (isSyncIterable(iterable)) {
@@ -18,7 +33,10 @@ export function take<T>(
     return new TakeIterator(limit, iterable);
 }
 
-export function *takeSync<T>(limit: number, iterable: Iterable<T>) {
+export function *takeSync<T>(
+    limit: number,
+    iterable: Iterable<T>
+): IterableIterator<T> {
     if (limit <= 0) return;
 
     let i = 0;

--- a/src/takeWhile.spec.ts
+++ b/src/takeWhile.spec.ts
@@ -1,9 +1,9 @@
 import { collect, takeWhile, range } from '.';
-import { asyncFibonacci } from './testIterators.fixture';
+import { asyncFibonacci, DECORATOR_ERROR_TEST_COUNT, testDecoratorErrorHandling, asyncify } from './testIterators.fixture';
 import * as test from 'tape';
 
 test('takeWhile', async t => {
-    t.plan(2)
+    t.plan(3)
 
     t.deepEqual(
         await collect(takeWhile((arg: number) => arg < 5, range(10))),
@@ -16,4 +16,17 @@ test('takeWhile', async t => {
         [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89],
         'should limit iteration of async iterables'
     )
+
+    const iter = (takeWhile(() => false, asyncify([0])) as any)[Symbol.asyncIterator]()
+    await iter.next();
+    t.ok(
+        (await iter.next()).done,
+        'should handle .next being called after iteration finishes'
+    );
 })
+
+test('takeWhile error handling', async t => {
+    t.plan(DECORATOR_ERROR_TEST_COUNT);
+
+    testDecoratorErrorHandling(takeWhile.bind(null, () => true), t, 'takeWhile')
+});

--- a/src/takeWhile.spec.ts
+++ b/src/takeWhile.spec.ts
@@ -6,7 +6,7 @@ test('takeWhile', async t => {
     t.plan(3)
 
     t.deepEqual(
-        await collect(takeWhile((arg: number) => arg < 5, range(10))),
+        [...takeWhile((arg: number) => arg < 5, range(10))],
         [0, 1, 2, 3, 4],
         'should limit iteration of sync iterables'
     )

--- a/src/takeWhile.ts
+++ b/src/takeWhile.ts
@@ -1,20 +1,62 @@
+import { AsyncIterableDecorator } from './AsyncIterableDecorator';
+import { isSyncIterable } from './isIterable';
+
 /**
  * Yields values from the provided iterable while they satisfy the provided
  * predicate.
  *
  * @param predicate A function that takes an element yielded by the provided
- *                  iterable and returns a boolean or a promise that resolves to
- *                  a boolean.
+ *                  iterable and returns a boolean.
  */
-export async function *takeWhile<T>(
+export function takeWhile<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<T>|AsyncIterableIterator<T> {
+    if (isSyncIterable(iterable)) {
+        return takeWhileSync(predicate, iterable);
+    }
+
+    return new TakeWhileIterator(predicate, iterable);
+}
+
+export function *takeWhileSync<T>(
     predicate: (arg: T) => boolean|Promise<boolean>,
     iterable: Iterable<T>|AsyncIterable<T>
 ) {
-    for await (const element of iterable) {
-        if (await predicate(element)) {
+    for (const element of iterable) {
+        if (predicate(element)) {
             yield element;
         } else {
             break;
         }
+    }
+}
+
+class TakeWhileIterator<T> extends AsyncIterableDecorator<T> {
+    private finished = false
+
+    constructor(
+        private readonly predicate: (arg: T) => boolean,
+        iterable: AsyncIterable<T>
+    ) {
+        super(iterable);
+    }
+
+    async next(): Promise<IteratorResult<T>> {
+        if (this.finished) {
+            return { done: true } as IteratorResult<T>;
+        }
+
+        const {value, done} = await this.iterator.next();
+        if (done || !(this.finished = !this.predicate(value))) {
+            return { done, value };
+        }
+
+        return this.return();
+    }
+
+    return() {
+        this.finished = true;
+        return super.return();
     }
 }

--- a/src/takeWhile.ts
+++ b/src/takeWhile.ts
@@ -10,6 +10,21 @@ import { isSyncIterable } from './isIterable';
  */
 export function takeWhile<T>(
     predicate: (arg: T) => boolean,
+    iterable: Iterable<T>
+): IterableIterator<T>;
+
+export function takeWhile<T>(
+    predicate: (arg: T) => boolean,
+    iterable: AsyncIterable<T>
+): AsyncIterableIterator<T>;
+
+export function takeWhile<T>(
+    predicate: (arg: T) => boolean,
+    iterable: Iterable<T>|AsyncIterable<T>
+): IterableIterator<T>|AsyncIterableIterator<T>;
+
+export function takeWhile<T>(
+    predicate: (arg: T) => boolean,
     iterable: Iterable<T>|AsyncIterable<T>
 ): IterableIterator<T>|AsyncIterableIterator<T> {
     if (isSyncIterable(iterable)) {
@@ -22,7 +37,7 @@ export function takeWhile<T>(
 export function *takeWhileSync<T>(
     predicate: (arg: T) => boolean|Promise<boolean>,
     iterable: Iterable<T>|AsyncIterable<T>
-) {
+): IterableIterator<T> {
     for (const element of iterable) {
         if (predicate(element)) {
             yield element;

--- a/src/tap.spec.ts
+++ b/src/tap.spec.ts
@@ -1,5 +1,6 @@
 import { range, tap } from '.';
 import * as test from 'tape';
+import { DECORATOR_ERROR_TEST_COUNT, testDecoratorErrorHandling } from './testIterators.fixture';
 
 test('tap', async t => {
     t.plan(1)
@@ -9,4 +10,10 @@ test('tap', async t => {
     for await (const _ of tapTransducer(range(5))) {}
 
     t.equal(count, 5)
-})
+});
+
+test('tap error handling', async t => {
+    t.plan(DECORATOR_ERROR_TEST_COUNT);
+
+    testDecoratorErrorHandling(tap.bind(null, async () => {}), t, 'tap');
+});

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -1,4 +1,4 @@
-import { iteratorFromIterable } from './iteratorFromIterable';
+import { AsyncIterableDecorator } from './AsyncIterableDecorator';
 
 /**
  * Execute an action for each value yielded by the provided iterable.
@@ -17,18 +17,12 @@ export function tap<T>(
     return new TapIterator(action, iterable);
 }
 
-class TapIterator<T> implements AsyncIterableIterator<T> {
-    private readonly iterator: Iterator<T>|AsyncIterator<T>;
-
+class TapIterator<T> extends AsyncIterableDecorator<T> {
     constructor(
         private readonly action: (arg: T) => void|Promise<void>,
         iterable: Iterable<T>|AsyncIterable<T>
     ) {
-        this.iterator = iteratorFromIterable(iterable);
-    }
-
-    [Symbol.asyncIterator]() {
-        return this;
+        super(iterable);
     }
 
     async next() {
@@ -38,13 +32,5 @@ class TapIterator<T> implements AsyncIterableIterator<T> {
         }
 
         return { done, value };
-    }
-
-    async return() {
-        if (typeof this.iterator.return === 'function') {
-            return this.iterator.return();
-        }
-
-        return { done: true } as IteratorResult<T>;
     }
 }

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -1,3 +1,5 @@
+import { iteratorFromIterable } from './iteratorFromIterable';
+
 /**
  * Execute an action for each value yielded by the provided iterable.
  *
@@ -8,12 +10,41 @@
  * @returns a iterable that will yield all values yielded by the provided
  * `iterable`.
  */
-export async function *tap<T>(
+export function tap<T>(
     action: (arg: T) => void|Promise<void>,
     iterable: Iterable<T>|AsyncIterable<T>
-) {
-    for await (const element of iterable) {
-        await action(element);
-        yield element;
+): AsyncIterableIterator<T> {
+    return new TapIterator(action, iterable);
+}
+
+class TapIterator<T> implements AsyncIterableIterator<T> {
+    private readonly iterator: Iterator<T>|AsyncIterator<T>;
+
+    constructor(
+        private readonly action: (arg: T) => void|Promise<void>,
+        iterable: Iterable<T>|AsyncIterable<T>
+    ) {
+        this.iterator = iteratorFromIterable(iterable);
+    }
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    async next() {
+        const { done, value } = await this.iterator.next();
+        if (!done) {
+            await this.action(value);
+        }
+
+        return { done, value };
+    }
+
+    async return() {
+        if (typeof this.iterator.return === 'function') {
+            return this.iterator.return();
+        }
+
+        return { done: true } as IteratorResult<T>;
     }
 }

--- a/src/testIterators.fixture.ts
+++ b/src/testIterators.fixture.ts
@@ -1,5 +1,7 @@
+import { Test } from 'tape';
+
 export async function *asyncFibonacci() {
-    yield* asyncify(fibonacci());
+    yield* new AsyncFibonacciSequence
 }
 
 export async function *asyncify<T>(iterable: Iterable<T>) {
@@ -11,16 +13,44 @@ export async function *asyncify<T>(iterable: Iterable<T>) {
     }
 }
 
-export function *fibonacci() {
-    yield 1;
+export class FibonacciSequence {
+    private a = 1;
+    private b = 1;
 
-    for (let i = 1, j = 1; true; [i, j] = [j, i + j]) {
-        yield j;
+    [Symbol.iterator]() {
+        return this;
+    }
+
+    next(): IteratorResult<number> {
+        const value = this.a;
+        [this.a, this.b] = [this.b, this.a + this.b];
+        return { done: false, value }
     }
 }
 
-export class IterationDisallowedError extends Error {
-    name = 'IterationDisallowedError';
+export class AsyncFibonacciSequence {
+    private readonly seq = new FibonacciSequence;
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    next(): Promise<IteratorResult<number>> {
+        const next = this.seq.next();
+        return new Promise(resolve => {
+            setTimeout(() => resolve(next), 0);
+        })
+    }
+}
+
+export function *fibonacci() {
+    yield* new FibonacciSequence;
+}
+
+const IterationDisallowedErrorName = 'IterationDisallowedError';
+
+class IterationDisallowedError extends Error {
+    name = IterationDisallowedErrorName;
 }
 
 export class ExplosiveIterator {
@@ -33,11 +63,65 @@ export class ExplosiveIterator {
     }
 }
 
-export class CloseHandlingIterator extends ExplosiveIterator {
+export class CloseHandlingIterator {
     returnCalled = false;
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    next(): Promise<IteratorResult<void>> {
+        return Promise.resolve({done: false} as IteratorResult<void>);
+    }
 
     return(): Promise<IteratorResult<void>> {
         this.returnCalled = true;
         return Promise.resolve({done: true} as IteratorResult<void>);
+    }
+}
+
+class ExplosiveCloseHandlingIterator extends CloseHandlingIterator {
+    next(): Promise<IteratorResult<void>> {
+        return Promise.reject(new IterationDisallowedError('PANIC'));
+    }
+}
+
+export const DECORATOR_ERROR_TEST_COUNT = 3;
+
+export async function testDecoratorErrorHandling(
+    decorator: (iterable: Iterable<any>|AsyncIterable<any>) => Iterable<any>|AsyncIterable<any>,
+    testRunner: Test,
+    name: string
+): Promise<void> {
+    try {
+        for await (const _ of decorator(new AsyncFibonacciSequence)) {
+            throw new Error('PANIC');
+        }
+    } catch {
+        testRunner.pass(
+            `${name} should allow aborting iteration of iterators with no defined return method`
+        );
+    }
+
+    const iter = new CloseHandlingIterator;
+    try {
+        for await (const _ of decorator(iter)) {
+            throw new Error('PANIC');
+        }
+    } catch {
+        testRunner.ok(
+            iter.returnCalled,
+            `${name} should call .return on the underlying iterator when iteration is aborted`
+        );
+    }
+
+    const errorIter = new ExplosiveCloseHandlingIterator;
+    try {
+        for await (const _ of decorator(errorIter)) {}
+    } catch (err) {
+        testRunner.ok(
+            iter.returnCalled,
+            `${name} should call .return on the underlying iterator when iteration is aborted`
+        );
     }
 }

--- a/src/testIterators.fixture.ts
+++ b/src/testIterators.fixture.ts
@@ -86,6 +86,15 @@ class ExplosiveCloseHandlingIterator extends CloseHandlingIterator {
     }
 }
 
+export class LazyInitializingIterator extends CloseHandlingIterator {
+    initialized = false;
+
+    [Symbol.asyncIterator]() {
+        this.initialized = true;
+        return this;
+    }
+}
+
 export const DECORATOR_ERROR_TEST_COUNT = 3;
 
 export async function testDecoratorErrorHandling(

--- a/src/testIterators.fixture.ts
+++ b/src/testIterators.fixture.ts
@@ -130,7 +130,7 @@ export async function testDecoratorErrorHandling(
     } catch (err) {
         testRunner.ok(
             iter.returnCalled,
-            `${name} should call .return on the underlying iterator when iteration is aborted`
+            `${name} should call .return on the underlying iterator when iteration triggers an error`
         );
     }
 }

--- a/src/testIterators.fixture.ts
+++ b/src/testIterators.fixture.ts
@@ -19,6 +19,25 @@ export function *fibonacci() {
     }
 }
 
-export function *throwOnIteration(): IterableIterator<never> {
-    throw new Error('PANIC PANIC');
+export class IterationDisallowedError extends Error {
+    name = 'IterationDisallowedError';
+}
+
+export class ExplosiveIterator {
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    next(): Promise<IteratorResult<void>> {
+        return Promise.reject(new IterationDisallowedError('PANIC'));
+    }
+}
+
+export class CloseHandlingIterator extends ExplosiveIterator {
+    returnCalled = false;
+
+    return(): Promise<IteratorResult<void>> {
+        this.returnCalled = true;
+        return Promise.resolve({done: true} as IteratorResult<void>);
+    }
 }

--- a/src/testIterators.fixture.ts
+++ b/src/testIterators.fixture.ts
@@ -1,9 +1,15 @@
 import { Test } from 'tape';
 
+/**
+ * @internal
+ */
 export async function *asyncFibonacci() {
     yield* new AsyncFibonacciSequence
 }
 
+/**
+ * @internal
+ */
 export async function *asyncify<T>(iterable: Iterable<T>) {
     for (const element of iterable) {
         yield element;
@@ -13,6 +19,9 @@ export async function *asyncify<T>(iterable: Iterable<T>) {
     }
 }
 
+/**
+ * @internal
+ */
 export class FibonacciSequence {
     private a = 1;
     private b = 1;
@@ -28,6 +37,9 @@ export class FibonacciSequence {
     }
 }
 
+/**
+ * @internal
+ */
 export class AsyncFibonacciSequence {
     private readonly seq = new FibonacciSequence;
 
@@ -43,7 +55,10 @@ export class AsyncFibonacciSequence {
     }
 }
 
-export function *fibonacci() {
+/**
+ * @internal
+ */
+export function *fibonacci(): IterableIterator<number> {
     yield* new FibonacciSequence;
 }
 
@@ -53,6 +68,9 @@ class IterationDisallowedError extends Error {
     name = IterationDisallowedErrorName;
 }
 
+/**
+ * @internal
+ */
 export class ExplosiveIterator {
     [Symbol.asyncIterator]() {
         return this;
@@ -63,6 +81,9 @@ export class ExplosiveIterator {
     }
 }
 
+/**
+ * @internal
+ */
 export class CloseHandlingIterator {
     returnCalled = false;
 
@@ -80,12 +101,18 @@ export class CloseHandlingIterator {
     }
 }
 
+/**
+ * @internal
+ */
 class ExplosiveCloseHandlingIterator extends CloseHandlingIterator {
     next(): Promise<IteratorResult<void>> {
         return Promise.reject(new IterationDisallowedError('PANIC'));
     }
 }
 
+/**
+ * @internal
+ */
 export class LazyInitializingIterator extends CloseHandlingIterator {
     initialized = false;
 
@@ -95,8 +122,14 @@ export class LazyInitializingIterator extends CloseHandlingIterator {
     }
 }
 
+/**
+ * @internal
+ */
 export const DECORATOR_ERROR_TEST_COUNT = 3;
 
+/**
+ * @internal
+ */
 export async function testDecoratorErrorHandling(
     decorator: (iterable: Iterable<any>|AsyncIterable<any>) => Iterable<any>|AsyncIterable<any>,
     testRunner: Test,

--- a/src/zip.spec.ts
+++ b/src/zip.spec.ts
@@ -1,5 +1,10 @@
 import { collect, range, zip } from '.';
-import { asyncify } from './testIterators.fixture';
+import {
+    asyncify,
+    DECORATOR_ERROR_TEST_COUNT,
+    FibonacciSequence,
+    testDecoratorErrorHandling,
+} from './testIterators.fixture';
 import * as test from 'tape';
 
 test('zip', async t => {
@@ -12,6 +17,21 @@ test('zip', async t => {
             range(0, 100, 2),
             range(1, 10, 2),
             [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]],
+        ],
+        [
+            range(0, 10, 2),
+            range(1, 100, 2),
+            [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]],
+        ],
+        [
+            range(0, 10, 2),
+            new FibonacciSequence,
+            [[0, 1], [2, 1], [4, 2], [6, 3], [8, 5]],
+        ],
+        [
+            new FibonacciSequence,
+            range(0, 10, 2),
+            [[1, 0], [1, 2], [2, 4], [3, 6], [5, 8]],
         ],
         [
             asyncify(range(0, 100, 2)),
@@ -39,4 +59,10 @@ test('zip', async t => {
             'should zip sync and async iterables together'
         )
     }
-})
+});
+
+test('zip error handling', async t => {
+   t.plan(DECORATOR_ERROR_TEST_COUNT);
+
+   testDecoratorErrorHandling(zip.bind(null, new FibonacciSequence()), t, 'zip')
+});

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,4 +1,5 @@
 import { iteratorFromIterable } from './iteratorFromIterable';
+import { isSyncIterable } from './isIterable';
 
 /**
  * Creates an iterable of tuple pairs that matches the iteration signature of
@@ -10,21 +11,85 @@ import { iteratorFromIterable } from './iteratorFromIterable';
  * @param keys      The values to use as the first member of each pair.
  * @param values    The values to use as the second member of each pair.
  */
-export async function *zip<K, V>(
+export function zip<K, V>(
     keys: AsyncIterable<K>|Iterable<K>,
     values: AsyncIterable<V>|Iterable<V>
-) {
-    const keyIterator = iteratorFromIterable(keys);
-    const valueIterator = iteratorFromIterable(values);
+): IterableIterator<[K, V]>|AsyncIterableIterator<[K, V]> {
+    if (isSyncIterable(keys) && isSyncIterable(values)) {
+        return zipSync(keys, values);
+    }
+
+    return new ZipIterator(keys, values);
+}
+
+export function *zipSync<K, V>(
+    keys: Iterable<K>,
+    values: Iterable<V>
+): IterableIterator<[K, V]> {
+    const keyIterator = keys[Symbol.iterator]();
+    const valueIterator = values[Symbol.iterator]();
 
     while (true) {
-        const {done: keysDone, value: key} = await keyIterator.next();
-        const {done: valuesDone, value} = await valueIterator.next();
+        const {done: keysDone, value: key} = keyIterator.next();
+        const {done: valuesDone, value} = valueIterator.next();
 
-        if (keysDone || valuesDone) {
+        if (keysDone) {
+            if (!valuesDone && typeof valueIterator.return === 'function') {
+                return valueIterator.return();
+            }
+
+            break;
+        }
+
+        if (valuesDone) {
+            if (!keysDone && typeof keyIterator.return === 'function') {
+                return keyIterator.return();
+            }
+
             break;
         }
 
         yield [key, value];
+    }
+}
+
+class ZipIterator<K, V> implements AsyncIterableIterator<[K, V]> {
+    private readonly keys: Iterator<K>|AsyncIterator<K>;
+    private keysDone = false
+    private readonly values: Iterator<V>|AsyncIterator<V>;
+    private valuesDone = false
+
+    constructor(
+        keys: Iterable<K>|AsyncIterable<K>,
+        values: Iterable<V>|AsyncIterable<V>
+    ) {
+        this.keys = iteratorFromIterable(keys);
+        this.values = iteratorFromIterable(values);
+    }
+
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+
+    async next() {
+        const {done: keysDone, value: key} = await this.keys.next();
+        const {done: valuesDone, value} = await this.values.next();
+
+        if ((this.keysDone = keysDone) || (this.valuesDone = valuesDone)) {
+            return this.return();
+        }
+
+        return { done: false, value: [key, value] as [K, V] };
+    }
+
+    async return() {
+        await Promise.all([
+            !this.keysDone && typeof this.keys.return === 'function' ?
+                this.keys.return() : Promise.resolve(),
+            !this.valuesDone && typeof this.values.return === 'function' ?
+                this.values.return() : Promise.resolve(),
+        ] as Array<Promise<any>>);
+
+        return { done: true } as IteratorResult<[K, V]>;
     }
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -6,11 +6,22 @@ import { isSyncIterable } from './isIterable';
  * an ES6 Map object.
  *
  * If the two provided iterables are different lengths, the resulting iterable
- * will be the same length as the shorter of the two.
+ * will be the same length as the shorter of the two. The longer iterable will
+ * be terminated early.
  *
  * @param keys      The values to use as the first member of each pair.
  * @param values    The values to use as the second member of each pair.
  */
+export function zip<K, V>(
+    keys: Iterable<K>,
+    values: Iterable<V>
+): IterableIterator<[K, V]>;
+
+export function zip<K, V>(
+    keys: Iterable<K>|AsyncIterable<K>,
+    values: Iterable<V>|AsyncIterable<V>
+): AsyncIterableIterator<[K, V]>;
+
 export function zip<K, V>(
     keys: AsyncIterable<K>|Iterable<K>,
     values: AsyncIterable<V>|Iterable<V>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,16 +17,14 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "noImplicitReturns": true
   },
   "typedocOptions": {
     "mode": "file",
     "out": "docs",
     "name": "async-seq",
-    "readme": "none",
-    "exclude": "**/*.spec.ts",
-    "excludeNotExported": true
+    "exclude": "**/*.+(spec|fixture).ts",
+    "excludeNotExported": true,
+    "excludePrivate": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
   "typedocOptions": {
     "mode": "file",
     "out": "docs",
-    "name": "async-seq",
+    "name": "@jsq/seq",
     "exclude": "**/*.+(spec|fixture).ts",
     "excludeNotExported": true,
     "excludePrivate": true


### PR DESCRIPTION
Rather than always using `for await ... of` loops, which handle both sync and async iterables, this PR ensures synchronous iteration is used on sync iterables.